### PR TITLE
replace IconButton with mui3

### DIFF
--- a/app/assets/javascripts/views/components/Browsing/card-view.js
+++ b/app/assets/javascripts/views/components/Browsing/card-view.js
@@ -28,7 +28,7 @@ import CardHeader from 'material-ui/Card/CardHeader';
 import CardMedia from 'material-ui/Card/CardMedia';
 import CardText from 'material-ui/Card/CardText';
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import FlatButton from 'material-ui/FlatButton';
 import IntlService from "views/services/intl";
 
@@ -101,7 +101,7 @@ export default class CardView extends Component {
 
                         <IconButton iconClassName="material-icons"
                                     style={{position: 'absolute', right: 0, zIndex: 1000}}
-                                    onClick={() => this.setState({showIntro: false})}>clear</IconButton>
+                                    onClick={() => this.setState({showIntro: false})}><Icon>clear</Icon></IconButton>
 
                         {this.intl.searchAndReplace(introduction)}
 
@@ -129,7 +129,7 @@ export default class CardView extends Component {
                                 'float': 'right'
                             }} tooltipPosition="top-left"
                                                onClick={() => this.setState({showIntro: !this.state.showIntro})}
-                                               touch={true}>flip_to_front</IconButton>;
+                                               touch={true}><Icon>flip_to_front</Icon></IconButton>;
                         }
                     })()}
 

--- a/app/assets/javascripts/views/components/Editor/BrowseComponent.js
+++ b/app/assets/javascripts/views/components/Editor/BrowseComponent.js
@@ -31,7 +31,7 @@ import GridTile from 'material-ui/GridList/GridTile';
 import MediaList from 'views/components/Browsing/media-list';
 import LinearProgress from 'material-ui/LinearProgress';
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import ActionInfo from '@material-ui/icons/Info';
 import ActionInfoOutline from '@material-ui/icons/InfoOutlined';
 

--- a/app/assets/javascripts/views/components/Editor/EditableComponent.js
+++ b/app/assets/javascripts/views/components/Editor/EditableComponent.js
@@ -15,7 +15,8 @@ import {Document} from 'nuxeo';
 import fields from 'models/schemas/fields';
 import options from 'models/schemas/options';
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
 import CircularProgress from 'material-ui/CircularProgress';
 import IntlService from "views/services/intl";
 
@@ -156,7 +157,7 @@ export default class EditableComponent extends Component {
                 width: '22px',
                 display: (this.props.accessDenied) ? 'none' : 'inline-block'
             }} onClick={this._onEditRequest.bind(this, property)}
-                        tooltip={intl.trans('edit', 'Edit', 'first')}>mode_edit</IconButton>
+            tooltip={intl.trans('edit', 'Edit', 'first')}><Icon>mode_edit</Icon></IconButton>
         </div>;
     }
 

--- a/app/assets/javascripts/views/components/Editor/SelectMediaComponent.js
+++ b/app/assets/javascripts/views/components/Editor/SelectMediaComponent.js
@@ -33,7 +33,7 @@ import withPagination from 'views/hoc/grid-list/with-pagination';
 import withFilter from 'views/hoc/grid-list/with-filter';
 import LinearProgress from 'material-ui/LinearProgress';
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import ActionInfo from '@material-ui/icons/Info';
 import ActionInfoOutline from '@material-ui/icons/InfoOutlined';
 import IntlService from "views/services/intl";

--- a/app/assets/javascripts/views/components/Geo/map.js
+++ b/app/assets/javascripts/views/components/Geo/map.js
@@ -31,7 +31,6 @@ import CardHeader from 'material-ui/Card/CardHeader';
 import CardMedia from 'material-ui/Card/CardMedia';
 import CardText from 'material-ui/Card/CardText';
 
-import IconButton from 'material-ui/IconButton';
 import FlatButton from 'material-ui/FlatButton';
 
 import CanadaGeoJSON from 'json-loader!models/data/map.geojson';

--- a/app/assets/javascripts/views/components/Kids/navigation.js
+++ b/app/assets/javascripts/views/components/Kids/navigation.js
@@ -39,7 +39,8 @@ import Badge from 'material-ui/Badge';
 import FlatButton from 'material-ui/FlatButton';
 import Toolbar from 'material-ui/Toolbar/Toolbar';
 import ToolbarGroup from 'material-ui/Toolbar/ToolbarGroup';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 
@@ -183,24 +184,24 @@ export default class Navigation extends Component {
                                 onClick={(e) => NavigationHelpers.navigateBack()}
                                 style={{paddingTop: 0, top: '8px', left: '-10px'}} iconClassName="material-icons"
                                 tooltipPosition="bottom-left"
-                                tooltip={intl.trans('back', 'Back', 'first')}>keyboard_backspace</IconButton>
+                                tooltip={intl.trans('back', 'Back', 'first')}><Icon>keyboard_backspace</Icon></IconButton>
 
                     <IconButton
                         onClick={this._onNavigateRequest.bind(this, '/kids' + (this.props.routeParams.dialect_path ? this.props.routeParams.dialect_path : ''))}
                         style={{paddingTop: 0, top: '8px', left: '-10px'}} iconClassName="material-icons"
-                        tooltipPosition="bottom-left" tooltip={intl.trans('home', 'Home', 'first')}>home</IconButton>
+                        tooltipPosition="bottom-left" tooltip={intl.trans('home', 'Home', 'first')}><Icon>home</Icon></IconButton>
 
                     <IconButton onClick={this._onNavigateRequest.bind(this, '/kids/FV/Workspaces/Data')}
                                 style={{paddingTop: 0, top: '8px', left: '-10px'}} iconClassName="material-icons"
                                 tooltipPosition="bottom-left"
-                                tooltip={intl.trans('choose_lang', 'Choose a Language', 'first')}>apps</IconButton>
+                                tooltip={intl.trans('choose_lang', 'Choose a Language', 'first')}><Icon>apps</Icon></IconButton>
 
                     <ToolbarSeparator style={{float: 'none', marginLeft: '0', marginRight: '15px'}}/>
 
                     <IconButton style={{paddingTop: 0, paddingRight: 0, top: '8px', left: '-10px'}}
                                 iconClassName="material-icons" onClick={this._onNavigateRequest.bind(this, '/')}
                                 tooltipPosition="bottom-left"
-                                tooltip={intl.trans('back_to_main_site', 'Back to Main Site', 'words')}>clear</IconButton>
+                                tooltip={intl.trans('back_to_main_site', 'Back to Main Site', 'words')}><Icon>clear</Icon></IconButton>
 
                 </ToolbarGroup>
 

--- a/app/assets/javascripts/views/components/Navigation/AppLeftNav/index.js
+++ b/app/assets/javascripts/views/components/Navigation/AppLeftNav/index.js
@@ -27,7 +27,8 @@ import Drawer from 'material-ui/Drawer'
 import AppBar from 'material-ui/AppBar'
 import { makeSelectable } from 'material-ui/List'
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+
 import NavigationClose from '@material-ui/icons/Close';
 
 import IntlService from 'views/services/intl';

--- a/app/assets/javascripts/views/components/Navigation/Login/index.js
+++ b/app/assets/javascripts/views/components/Navigation/Login/index.js
@@ -23,7 +23,6 @@ import selectn from 'selectn';
 // Components
 import Popover from 'material-ui/Popover';
 import FlatButton from 'material-ui/FlatButton';
-import IconButton from 'material-ui/IconButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 

--- a/app/assets/javascripts/views/components/Navigation/index.js
+++ b/app/assets/javascripts/views/components/Navigation/index.js
@@ -48,7 +48,8 @@ import FlatButton from 'material-ui/FlatButton';
 
 import Toolbar from 'material-ui/Toolbar/Toolbar';
 import ToolbarGroup from 'material-ui/Toolbar/ToolbarGroup';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import ActionHelp from '@material-ui/icons/Help';
@@ -411,7 +412,7 @@ export default class Navigation extends Component {
                 iconClassName="material-icons"
                 style={{position:'relative', top: '7px', padding: '0', left: 0}}
                 iconStyle={{fontSize: '24px', padding: '3px', borderRadius: '20px', color: '#FFFFFF'}}>
-                search
+                <Icon>search</Icon>
             </IconButton>
 
             <Popover
@@ -502,7 +503,7 @@ export default class Navigation extends Component {
               iconClassName="material-icons"
               style={{position:'relative', top: '7px', padding: '0', left: 0}}
               iconStyle={{fontSize: '24px', padding: '3px', borderRadius: '20px', color: '#FFFFFF'}}>
-              settings
+              <Icon>settings</Icon>
           </IconButton>
 
           </ToolbarGroup>

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/base/grid-view.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/base/grid-view.js
@@ -26,7 +26,7 @@ import * as Colors from 'material-ui/styles/colors';
 import GridList from 'material-ui/GridList/GridList';
 import GridTile from 'material-ui/GridList/GridTile';
 
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 
 import AVPlayArrow from '@material-ui/icons/PlayArrow';
 import AVStop from '@material-ui/icons/Stop';

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
@@ -33,7 +33,6 @@ import RaisedButton from 'material-ui/RaisedButton';
 import FlatButton from 'material-ui/FlatButton';
 
 import IconMenu from 'material-ui/IconMenu';
-import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
 import NavigationExpandMoreIcon from '@material-ui/icons/ExpandMore';
 

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/list-view.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/list-view.js
@@ -39,7 +39,8 @@ import CardMedia from 'material-ui/Card/CardMedia';
 import CardText from 'material-ui/Card/CardText';
 
 import FlatButton from 'material-ui/FlatButton';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
 
 import Tabs from 'material-ui/Tabs/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
@@ -186,7 +187,7 @@ class CardView extends Component {
 
                         <IconButton iconClassName="material-icons"
                                     style={{position: 'absolute', right: 0, zIndex: 1000}}
-                                    onClick={() => this.setState({showIntro: false})}>clear</IconButton>
+                                    onClick={() => this.setState({showIntro: false})}><Icon>clear</Icon></IconButton>
 
                         {(() => {
                             if (selectn('properties.fvbook:introduction', this.props.item)) {
@@ -218,7 +219,7 @@ class CardView extends Component {
                                 'float': 'right'
                             }} tooltipPosition="top-left"
                                                onClick={() => this.setState({showIntro: !this.state.showIntro})}
-                                               touch={true}>flip_to_front</IconButton>;
+                                               touch={true}><Icon>flip_to_front</Icon></IconButton>;
                         }
                     })()}
 

--- a/app/assets/javascripts/views/pages/explore/dialect/media/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/media/index.js
@@ -37,7 +37,6 @@ import { Toolbar, ToolbarGroup, ToolbarSeparator } from 'material-ui/Toolbar';
 import FlatButton from 'material-ui/FlatButton';
 import CircularProgress from 'material-ui/CircularProgress';
 import IconMenu from 'material-ui/IconMenu';
-import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
 import NavigationExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Tabs, Tab } from 'material-ui/Tabs';

--- a/app/assets/javascripts/views/pages/explore/dialect/page-stats.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/page-stats.js
@@ -32,7 +32,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Toggle from 'material-ui/Toggle';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import NavigationExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import CircularProgress from 'material-ui/CircularProgress';
 

--- a/app/assets/javascripts/views/pages/explore/dialect/play/wordscramble/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/play/wordscramble/index.js
@@ -22,7 +22,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 import * as Colors from 'material-ui/styles/colors';
 import FontIcon from 'material-ui/FontIcon';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
 import AVPlayArrow from '@material-ui/icons/PlayArrow';
 import AVStop from '@material-ui/icons/Stop';
 

--- a/app/assets/javascripts/views/pages/explore/dialect/reports/list-view.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/reports/list-view.js
@@ -38,7 +38,6 @@ import CardMedia from 'material-ui/Card/CardMedia';
 import CardText from 'material-ui/Card/CardText';
 
 import FlatButton from 'material-ui/FlatButton';
-import IconButton from 'material-ui/IconButton';
 
 import Tabs from 'material-ui/Tabs/Tabs';
 import Tab from 'material-ui/Tabs/Tab';

--- a/app/assets/javascripts/views/pages/explore/dialect/search-bar.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/search-bar.js
@@ -22,7 +22,8 @@ import selectn from 'selectn';
 import provide from 'react-redux-provide';
 
 import TextField from 'material-ui/TextField';
-import IconButton from 'material-ui/IconButton';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
 
 import ProviderHelpers from 'common/ProviderHelpers';
 import IntlService from 'views/services/intl';
@@ -70,7 +71,7 @@ export default class SearchBar extends Component {
                        onEnterKeyDown={this._handleDialectSearchSubmit}/>
             <IconButton onClick={this._handleDialectSearchSubmit} iconClassName="material-icons"
                         iconStyle={{fontSize: '24px'}}
-                        tooltip={intl.trans('search', 'Search', 'first')}>search</IconButton>
+                        tooltip={intl.trans('search', 'Search', 'first')}><Icon>search</Icon></IconButton>
         </div>;
     }
 }

--- a/app/assets/javascripts/views/pages/explore/dialect/users/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/users/index.js
@@ -37,7 +37,6 @@ import { Toolbar, ToolbarGroup, ToolbarSeparator } from 'material-ui/Toolbar';
 import FlatButton from 'material-ui/FlatButton';
 import CircularProgress from 'material-ui/CircularProgress';
 import IconMenu from 'material-ui/IconMenu';
-import IconButton from 'material-ui/IconButton';
 import MenuItem from 'material-ui/MenuItem';
 import NavigationExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Tabs, Tab } from 'material-ui/Tabs';

--- a/app/assets/javascripts/views/pages/search/index.js
+++ b/app/assets/javascripts/views/pages/search/index.js
@@ -30,8 +30,6 @@ import options from 'models/schemas/filter-options';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
-import IconButton from 'material-ui/IconButton';
-
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 

--- a/app/assets/javascripts/views/pages/users/login/index.js
+++ b/app/assets/javascripts/views/pages/users/login/index.js
@@ -26,7 +26,6 @@ import ProviderHelpers from 'common/ProviderHelpers';
 import PromiseWrapper from 'views/components/Document/PromiseWrapper';
 
 import FlatButton from 'material-ui/FlatButton';
-import IconButton from 'material-ui/IconButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 


### PR DESCRIPTION
This updates all IconButton components to new mui3 components. I opted to use <Icon> instead of importing specific icons (mostly because I was halfway through when I realized that we could import specific Icons). Should we import specific icons instead?